### PR TITLE
fix(add-content-to-project): correct addProjectV2ItemById jq path so Set-fields gets the item id

### DIFF
--- a/.github/workflows/add-content-to-project.yml
+++ b/.github/workflows/add-content-to-project.yml
@@ -78,7 +78,7 @@ jobs:
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f content=$CONTENT_ID --jq '.data.addProjectV2Item.item.id')"
+            }' -f project=$PROJECT_ID -f content=$CONTENT_ID --jq '.data.addProjectV2ItemById.item.id')"
           
           echo 'ITEM_ID='$item_id >> $GITHUB_ENV
 


### PR DESCRIPTION
## Problem
`add-content-to-project.yml` fails at the **Set fields** step on every opened issue (org-wide — every repo that calls this reusable workflow). Example run: HAL.McNeel run 29259670994 — `gh: Could not resolve to a node with the global id of ''`.

## Root cause
The **Add content to project** step captures the new project item id with:
```
--jq '.data.addProjectV2Item.item.id'
```
but the mutation field is `addProjectV2ItemById` (line 76). The jq path is missing `ById`, so `item_id` is always `null` → `ITEM_ID=''` → the **Set fields** `updateProjectV2ItemFieldValue` runs with `itemId=''` and fails.

## Fix
One character-path correction on the `--jq` filter:
```diff
- --jq '.data.addProjectV2Item.item.id'
+ --jq '.data.addProjectV2ItemById.item.id'
```

## Effect / note
The `addProjectV2ItemById` mutation itself succeeds, so affected issues **were added to the board** — only their Status was never set. After this lands, new issues register correctly; existing items opened during the broken window (failing since ~2026-07-06) need a one-time Status backfill (filter board #32 for empty Status → set Todo).

Not fixed here (pre-existing deprecations, separate concern): `tibdex/github-app-token@v1.5.0` (Node 20 EOL) and a `set-output` usage elsewhere.

— *PR opened by [Claude Code](https://claude.ai/code) on behalf of @thibaultschwartz.*
